### PR TITLE
instance MonadIO (FreeT f m)

### DIFF
--- a/Control/Monad/Trans/Free.hs
+++ b/Control/Monad/Trans/Free.hs
@@ -28,6 +28,7 @@ module Control.Monad.Trans.Free (
 
 import Control.Applicative
 import Control.Monad
+import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 import Data.Functor.Identity
 
@@ -78,6 +79,9 @@ instance (Functor f, Monad m) => Monad (FreeT f m) where
         runFreeT $ case x of
             Return r -> f r
             Wrap   w -> wrap $ fmap (>>= f) w
+
+instance (Functor f, MonadIO m) => MonadIO (FreeT f m) where
+    liftIO = lift . liftIO
 
 instance MonadTrans (FreeT f) where
     lift = FreeT . liftM Return


### PR DESCRIPTION
I was just writing up [an answer on StackOverflow](http://stackoverflow.com/a/11604953/208257) using Control.Pipe, and realized that Pipe is not an instance of MonadIO. Given the dependency on transformers is already there, I see no reason to omit it. You may want to consider adding an IMonadIO class to index-core as well.
