### PR TITLE
Fix to Tutorial

### DIFF
--- a/Control/Proxy/Tutorial.hs
+++ b/Control/Proxy/Tutorial.hs
@@ -157,7 +157,7 @@ import Prelude hiding (catch)
     The following program never brings more than a single line into memory (not
     that it matters for such a small file):
 
->>> withFile "test.txt" $ \h -> runProxy $ lines' h >-> printer
+>>> withFile "test.txt" ReadMode $ \h -> runProxy $ lines' h >-> printer
 Received a value:
 "Line 1"
 Received a value:


### PR DESCRIPTION
I was expecting the tutorial to be a literate Haskell file. Which would have allowed me to check that this correction type checked. Is there any reason that it isn't?
