### PR TITLE
Make module refs in description hyperlinks

### DIFF
--- a/pipes.cabal
+++ b/pipes.cabal
@@ -30,9 +30,13 @@ Description:
   .
   * /Extensive Documentation/: Second to none!
   .
-  Import "Control.Proxy" to use the library.
+  Import
+  @<http://hackage.haskell.org/packages/archive/pipes/latest/doc/html/Control-Proxy.html Control.Proxy>@
+  to use the library.
   .
-  Read "Control.Proxy.Tutorial" for a really extensive tutorial.
+  Read
+  @<http://hackage.haskell.org/packages/archive/pipes/latest/doc/html/Control-Proxy-Tutorial.html Control.Proxy.Tutorial>@
+  for a really extensive tutorial.
 Category: Control, Pipes, Proxies
 Tested-With: GHC ==7.4.1
 Source-Repository head


### PR DESCRIPTION
I kept getting annoyed by not being able to click these, having to hunt them down in the module listing manually.

Downsides to this solution:
- The links are for the latest built version on Hackage, even if you're browsing an older version
- If you install with `--enable-documentation` these links will go to Hackage and not your local offline documentation
- It needs a recent Haddock to render correctly, which isn't a problem on Hackage but could be with locally build documentation

The upside, of course, is that you now _can_ click the module references in the description on the Hackage page for pipes.

Pull at your discretion!
