### PR TITLE
Fixed trailing whitespace.

### DIFF
--- a/src/Pipes/Lift.hs
+++ b/src/Pipes/Lift.hs
@@ -26,7 +26,7 @@ module Pipes.Lift (
     -- $writert
     runWriterP,
     execWriterP,
-    
+
     -- * RWST
     runRWSP,
     evalRWSP,


### PR DESCRIPTION
Stupid GitHub editor introduced trailing whitespace.
