### PR TITLE
Add travis automation for building and running the benchmarks

### DIFF
--- a/.travis.ceh
+++ b/.travis.ceh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Gergely Risko, 2013.  gergely@risko.hu
+#
+# Public domain.  Please relicense this script any way you see fit.
+# I encourage you copying this to your own Travis tested project.
+# If license questions come up, please email me.
+#
+# This is only for the travis integration of HFlags, HFlags itself is
+# still licensed Apache License Version 2.0, for more info see COPYING.
+
+set -e
+set -x
+
+sudo mkdir /opt/ceh /nix
+sudo chown $USER. /opt/ceh /nix
+chmod 0700 /opt/ceh /nix
+cd /opt/ceh
+git clone git://github.com/errge/ceh.git .
+ln -s $HOME home
+/opt/ceh/scripts/ceh-init.sh

--- a/.travis.main
+++ b/.travis.main
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Gergely Risko, 2013.  gergely@risko.hu
+#
+# Public domain.  Please relicense this script any way you see fit.
+# I encourage you copying this to your own Travis tested project.
+# If license questions come up, please email me.
+#
+# This is only for the travis integration of HFlags, HFlags itself is
+# still licensed Apache License Version 2.0, for more info see COPYING.
+
+set -e
+set -x
+
+. /opt/ceh/scripts/ceh-profile.sh
+
+cabal update
+cabal install --only-dependencies --enable-tests --enable-benchmarks
+cabal configure --user --enable-tests --enable-benchmarks
+cabal build
+cabal bench
+cabal install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+# Gergely Risko, 2013.  gergely@risko.hu
+#
+# Public domain.  Please relicense this script any way you see fit.
+# I encourage you copying this to your own Travis tested project.
+# If license questions come up, please email me.
+#
+# This is only for the travis integration of HFlags, HFlags itself is
+# still licensed Apache License Version 2.0, for more info see COPYING.
+language: c
+install: bash ./.travis.ceh
+script: bash ./.travis.main
+env:
+  - CEH_GHC64=
+  - CEH_GHC64=1


### PR DESCRIPTION
You can check the current build status here:
https://travis-ci.org/errge/Haskell-Pipes-Library/builds/11053151

Both architecture (amd64 and i686) fails, because the benchmarks fail.  This is not a travis issue, it fails on my home machine too.

Using Ceh, so we can get GHC 7.6.3 with a lot of packages and on both architectures.  Travis only supports GHC 7.4 and only on amd64.

More about Ceh, if you are interested: http://www.gergely.risko.hu/fpafternoon-zurich-20130829/ceh.html
