### PR TITLE
Proposal for better handling of unexpected requests/responses

### DIFF
--- a/src/Pipes.hs
+++ b/src/Pipes.hs
@@ -70,6 +70,7 @@ import Control.Monad.Trans.Identity (IdentityT(runIdentityT))
 import Control.Monad.Trans.Maybe (MaybeT(runMaybeT))
 import Data.Foldable (Foldable)
 import qualified Data.Foldable as F
+import Data.Void (absurd)
 import Pipes.Internal (Proxy(..))
 import Pipes.Core
 
@@ -377,7 +378,7 @@ next :: (Monad m) => Producer a m r -> m (Either r (a, Producer a m r))
 next = go
   where
     go p = case p of
-        Request _ fu -> go (fu ())
+        Request v _  -> absurd v
         Respond a fu -> return (Right (a, fu ()))
         M         m  -> m >>= go
         Pure    r    -> return (Left r)

--- a/src/Pipes/Core.hs
+++ b/src/Pipes/Core.hs
@@ -88,7 +88,7 @@ module Pipes.Core (
     (<<+)
     ) where
 
-import Data.Void (Void)
+import Data.Void (Void, absurd)
 import Pipes.Internal (Proxy(..))
 
 {- $proxy
@@ -126,8 +126,8 @@ runEffect :: (Monad m) => Effect m r -> m r
 runEffect = go
   where
     go p = case p of
-        Request _ fa  -> go (fa  ())
-        Respond _ fb' -> go (fb' ())
+        Request v _ -> absurd v
+        Respond v _ -> absurd v
         M       m   -> m >>= go
         Pure    r   -> return r
 {-# INLINABLE runEffect #-}

--- a/src/Pipes/Prelude.hs
+++ b/src/Pipes/Prelude.hs
@@ -86,6 +86,7 @@ import Control.Exception (throwIO, try)
 import Control.Monad (liftM, replicateM_, when, unless)
 import Control.Monad.Trans.State.Strict (get, put)
 import Data.Functor.Identity (Identity, runIdentity)
+import Data.Void (absurd)
 import Foreign.C.Error (Errno(Errno), ePIPE)
 import qualified GHC.IO.Exception as G
 import Pipes
@@ -368,7 +369,7 @@ fold :: (Monad m) => (x -> a -> x) -> x -> (x -> b) -> Producer a m () -> m b
 fold step begin done p0 = loop p0 begin
   where
     loop p x = case p of
-        Request _  fu -> loop (fu ()) x
+        Request v  _  -> absurd v
         Respond a  fu -> loop (fu ()) $! step x a
         M          m  -> m >>= \p' -> loop p' x
         Pure    _     -> return (done x)
@@ -383,7 +384,7 @@ foldM step begin done p0 = do
     loop p0 x0
   where
     loop p x = case p of
-        Request _  fu -> loop (fu ()) x
+        Request v  _  -> absurd v
         Respond a  fu -> do
             x' <- step x a
             loop (fu ()) $! x'
@@ -517,7 +518,7 @@ toList :: Producer a Identity () -> [a]
 toList = loop
   where
     loop p = case p of
-        Request _ fu -> loop (fu ())
+        Request v _  -> absurd v
         Respond a fu -> a:loop (fu ())
         M         m  -> loop (runIdentity m)
         Pure    _    -> []
@@ -534,7 +535,7 @@ toListM :: (Monad m) => Producer a m () -> m [a]
 toListM = loop
   where
     loop p = case p of
-        Request _ fu -> loop (fu ())
+        Request v _  -> absurd v
         Respond a fu -> do
             as <- loop (fu ())
             return (a:as)
@@ -591,7 +592,7 @@ tee p = evalStateP Nothing $ do
         a <- await
         lift $ put (Just a)
         return a
-    dn _ = return ()
+    dn v = absurd v
 {-# INLINABLE tee #-}
 
 {-| Transform a unidirectional 'Pipe' to a bidirectional 'Proxy'


### PR DESCRIPTION
Requests/responses leaking out of an Effect (and similarly
Producers/Consumers) can only be some kind of bottoms. Instead of
silently ignoring these we evaluate them, so the user is aware of the
error and gets the original error from the faulty
Effect/Producer/Consumer.
