### PR TITLE
Add conditional compilation of a pipes subset to Haskell98.

### DIFF
--- a/pipes.cabal
+++ b/pipes.cabal
@@ -39,14 +39,22 @@ Source-Repository head
     Location: https://github.com/Gabriel439/Haskell-Pipes-Library
 
 Library
-    Default-Language: Haskell2010
+    if !flag(haskell98)
+        Default-Language: Haskell2010
+    else
+        Default-Language: Haskell98
+
     HS-Source-Dirs: src
     Build-Depends:
         base         >= 4       && < 5  ,
-        mmorph       >= 1.0.0   && < 1.1,
-        mtl          >= 2.0.1.0 && < 2.2,
         transformers >= 0.2.0.0 && < 0.4,
         void                       < 0.7
+
+    if !flag(haskell98)
+        Build-Depends:
+            mmorph       >= 1.0.0   && < 1.1,
+            mtl          >= 2.0.1.0 && < 2.2
+
     Exposed-Modules:
         Pipes,
         Pipes.Core,
@@ -55,6 +63,10 @@ Library
         Pipes.Prelude,
         Pipes.Tutorial
     GHC-Options: -O2 -Wall
+
+    if flag(haskell98)
+      CPP-Options: -Dhaskell98
+
 
 Benchmark prelude-benchmarks
     Default-Language: Haskell2010
@@ -99,3 +111,7 @@ Benchmark lift-benchmarks
         mtl          >= 2.0.1.0 && < 2.2,
         pipes        >= 4.0.0   && < 4.1,
         transformers >= 0.2.0.0 && < 0.4
+
+Flag haskell98
+  Description: Haskell98 compliant subset of pipes.
+  Default:     False

--- a/src/Pipes/Internal.hs
+++ b/src/Pipes/Internal.hs
@@ -33,15 +33,20 @@ module Pipes.Internal (
     ) where
 
 import Control.Applicative (Applicative(pure, (<*>)), Alternative(empty, (<|>)))
-import Control.Monad (liftM, MonadPlus(..))
+import Control.Monad (MonadPlus(..))
 import Control.Monad.IO.Class (MonadIO(liftIO))
+#ifndef haskell98
 import Control.Monad.Morph (MFunctor(hoist))
+#endif
 import Control.Monad.Trans.Class (MonadTrans(lift))
+#ifndef haskell98
+import Control.Monad (liftM)
 import Control.Monad.Error (MonadError(..))
 import Control.Monad.Reader (MonadReader(..))
 import Control.Monad.State (MonadState(..))
 import Control.Monad.Writer (MonadWriter(..))
 import Data.Monoid (mempty,mappend)
+#endif
 
 {-| A 'Proxy' is a monad transformer that receives and sends information on both
     an upstream and downstream interface.
@@ -129,6 +134,7 @@ unsafeHoist nat = go
         Pure       r   -> Pure r
 {-# INLINABLE unsafeHoist #-}
 
+#ifndef haskell98
 instance MFunctor (Proxy a' a b' b) where
     hoist nat p0 = go (observe p0) where
         go p = case p of
@@ -136,10 +142,12 @@ instance MFunctor (Proxy a' a b' b) where
             Respond b  fb' -> Respond b  (\b' -> go (fb' b'))
             M          m   -> M (nat (m >>= \p' -> return (go p')))
             Pure       r   -> Pure r
+#endif
 
 instance (MonadIO m) => MonadIO (Proxy a' a b' b m) where
     liftIO m = M (liftIO (m >>= \r -> return (Pure r)))
 
+#ifndef haskell98
 instance (MonadReader r m) => MonadReader r (Proxy a' a b' b m) where
     ask = lift ask
     local f = go
@@ -151,7 +159,6 @@ instance (MonadReader r m) => MonadReader r (Proxy a' a b' b m) where
               M       m      -> M (go `liftM` local f m)
 #if MIN_VERSION_mtl(2,1,0)
     reader = lift . reader
-#else
 #endif
 
 instance (MonadState s m) => MonadState s (Proxy a' a b' b m) where
@@ -159,13 +166,11 @@ instance (MonadState s m) => MonadState s (Proxy a' a b' b m) where
     put = lift . put
 #if MIN_VERSION_mtl(2,1,0)
     state = lift . state
-#else
 #endif
 
 instance (MonadWriter w m) => MonadWriter w (Proxy a' a b' b m) where
 #if MIN_VERSION_mtl(2,1,0)
     writer = lift . writer
-#else
 #endif
     tell = lift . tell
     listen p0 = go p0 mempty
@@ -199,6 +204,7 @@ instance (MonadError e m) => MonadError e (Proxy a' a b' b m) where
             M          m   -> M ((do
                 p' <- m
                 return (go p') ) `catchError` (\e -> return (f e)) )
+#endif
 
 instance (MonadPlus m) => Alternative (Proxy a' a b' b m) where
     empty = mzero

--- a/src/Pipes/Lift.hs
+++ b/src/Pipes/Lift.hs
@@ -2,46 +2,61 @@
     'Control.Monad.Trans.Class.lift'ed.  These functions lift these remaining
     actions so that they work in the 'Proxy' monad transformer.
 -}
+{-# LANGUAGE CPP #-}
 
 module Pipes.Lift (
     -- * ErrorT
-    errorP,
-    runErrorP,
-    catchError,
-    liftCatchError,
+      errorP
+#ifndef haskell98
+    , runErrorP
+    , catchError
+#endif
+    , liftCatchError
 
     -- * MaybeT
-    maybeP,
-    runMaybeP,
+    , maybeP
+#ifndef haskell98
+    , runMaybeP
+#endif
 
     -- * ReaderT
-    readerP,
-    runReaderP,
+    , readerP
+#ifndef haskell98
+    , runReaderP
+#endif
 
     -- * StateT
-    stateP,
-    runStateP,
-    evalStateP,
-    execStateP,
+    , stateP
+#ifndef haskell98
+    , runStateP
+    , evalStateP
+    , execStateP
+#endif
 
     -- * WriterT
     -- $writert
-    writerP,
-    runWriterP,
-    execWriterP,
+    , writerP
+#ifndef haskell98
+    , runWriterP
+    , execWriterP
+#endif
 
     -- * RWST
-    rwsP,
-    runRWSP,
-    evalRWSP,
-    execRWSP,
+    , rwsP
+#ifndef haskell98
+    , runRWSP
+    , evalRWSP
+    , execRWSP
 
     -- * Utilities
-    distribute
+    , distribute
+#endif
 
     ) where
 
+#ifndef haskell98
 import Control.Monad.Morph (hoist, MFunctor(..))
+#endif
 import Control.Monad.Trans.Class (lift, MonadTrans(..))
 import qualified Control.Monad.Trans.Error as E
 import qualified Control.Monad.Trans.Maybe as M
@@ -51,7 +66,9 @@ import qualified Control.Monad.Trans.Writer.Strict as W
 import qualified Control.Monad.Trans.RWS.Strict as RWS
 import Data.Monoid (Monoid)
 import Pipes.Internal (Proxy(..), unsafeHoist)
+#ifndef haskell98
 import Pipes.Core (runEffect, request, respond, (//>), (>\\))
+#endif
 
 -- | Wrap the base monad in 'E.ErrorT'
 errorP
@@ -63,6 +80,7 @@ errorP p = do
     lift $ E.ErrorT (return x)
 {-# INLINABLE errorP #-}
 
+#ifndef haskell98
 -- | Run 'E.ErrorT' in the base monad
 runErrorP
     :: (Monad m, E.Error e)
@@ -82,6 +100,7 @@ catchError
 catchError e h = errorP . E.runErrorT $ 
     E.catchError (distribute e) (distribute . h)
 {-# INLINABLE catchError #-}
+#endif
 
 -- | Catch an error using a catch function for the base monad
 liftCatchError
@@ -114,6 +133,7 @@ maybeP p = do
     lift $ M.MaybeT (return x)
 {-# INLINABLE maybeP #-}
 
+#ifndef haskell98
 -- | Run 'M.MaybeT' in the base monad
 runMaybeP
     :: (Monad m)
@@ -121,6 +141,7 @@ runMaybeP
     -> Proxy a' a b' b m (Maybe r)
 runMaybeP p = M.runMaybeT $ distribute p
 {-# INLINABLE runMaybeP #-}
+#endif
 
 -- | Wrap the base monad in 'R.ReaderT'
 readerP
@@ -131,6 +152,7 @@ readerP k = do
     unsafeHoist lift (k i)
 {-# INLINABLE readerP #-}
 
+#ifndef haskell98
 -- | Run 'R.ReaderT' in the base monad
 runReaderP
     :: (Monad m)
@@ -139,6 +161,7 @@ runReaderP
     -> Proxy a' a b' b m r
 runReaderP r p = (`R.runReaderT` r) $ distribute p
 {-# INLINABLE runReaderP #-}
+#endif
 
 -- | Wrap the base monad in 'S.StateT'
 stateP
@@ -151,6 +174,7 @@ stateP k = do
     return r
 {-# INLINABLE stateP #-}
 
+#ifndef haskell98
 -- | Run 'S.StateT' in the base monad
 runStateP
     :: (Monad m)
@@ -177,6 +201,7 @@ execStateP
     -> Proxy a' a b' b m s
 execStateP s p = fmap snd $ runStateP s p
 {-# INLINABLE execStateP #-}
+#endif
 
 {- $writert
     Note that 'runWriterP' and 'execWriterP' will keep the accumulator in
@@ -199,6 +224,7 @@ writerP p = do
     return r
 {-# INLINABLE writerP #-}
 
+#ifndef haskell98
 -- | Run 'W.WriterT' in the base monad
 runWriterP
     :: (Monad m, Data.Monoid.Monoid w)
@@ -214,7 +240,7 @@ execWriterP
     -> Proxy a' a b' b m w
 execWriterP p = fmap snd $ runWriterP p
 {-# INLINABLE execWriterP #-}
-
+#endif
 
 -- | Wrap the base monad in 'RWS.RWST'
 rwsP
@@ -231,6 +257,7 @@ rwsP k = do
     return r
 {-# INLINABLE rwsP #-}
 
+#ifndef haskell98
 -- | Run 'RWS.RWST' in the base monad
 runRWSP
     :: (Monad m, Monoid w)
@@ -282,3 +309,4 @@ distribute p =  runEffect $ request' >\\ unsafeHoist (hoist lift) p //> respond'
     request' = lift . lift . request
     respond' = lift . lift . respond
 {-# INLINABLE distribute #-}
+#endif

--- a/src/Pipes/Prelude.hs
+++ b/src/Pipes/Prelude.hs
@@ -25,81 +25,88 @@
 module Pipes.Prelude (
     -- * Producers
     -- $producers
-    stdinLn,
-    readLn,
-    fromHandle,
-    replicateM,
+      stdinLn
+    , readLn
+    , fromHandle
+    , replicateM
 
     -- * Consumers
     -- $consumers
-    stdoutLn,
-    print,
-    toHandle,
+    , stdoutLn
+    , print
+    , toHandle
 
     -- * Pipes
     -- $pipes
-    map,
-    mapM,
-    mapFoldable,
-    filter,
-    filterM,
-    take,
-    takeWhile,
-    drop,
-    dropWhile,
-    concat,
-    elemIndices,
-    findIndices,
-    scan,
-    scanM,
-    chain,
-    read,
-    show,
+    , map
+    , mapM
+    , mapFoldable
+    , filter
+    , filterM
+    , take
+    , takeWhile
+    , drop
+    , dropWhile
+    , concat
+    , elemIndices
+    , findIndices
+    , scan
+    , scanM
+    , chain
+    , read
+    , show
 
     -- * Folds
     -- $folds
-    fold,
-    foldM,
-    all,
-    any,
-    and,
-    or,
-    elem,
-    notElem,
-    find,
-    findIndex,
-    head,
-    index,
-    last,
-    length,
-    maximum,
-    minimum,
-    null,
-    sum,
-    product,
-    toList,
-    toListM,
+    , fold
+    , foldM
+    , all
+    , any
+    , and
+    , or
+    , elem
+    , notElem
+    , find
+    , findIndex
+    , head
+    , index
+    , last
+    , length
+    , maximum
+    , minimum
+    , null
+    , sum
+    , product
+    , toList
+    , toListM
 
     -- * Zips
-    zip,
-    zipWith,
-
+    , zip
+    , zipWith
+#ifndef haskell98
     -- * Utilities
-    tee,
-    generalize
+    , tee
+    , generalize
+#endif
     ) where
 
 import Control.Exception (throwIO, try)
 import Control.Monad (liftM, replicateM_, when, unless)
+#ifndef haskell98
 import Control.Monad.Trans.State.Strict (get, put)
+#endif
 import Data.Functor.Identity (Identity, runIdentity)
 import Data.Void (absurd)
 import Foreign.C.Error (Errno(Errno), ePIPE)
 import qualified GHC.IO.Exception as G
 import Pipes
+#ifndef haskell98
 import Pipes.Core
+#endif
 import Pipes.Internal
+#ifndef haskell98
 import Pipes.Lift (evalStateP)
+#endif
 import qualified System.IO as IO
 import qualified Prelude
 import Prelude hiding (
@@ -669,6 +676,7 @@ zipWith f = go
                         go p1' p2'
 {-# INLINABLE zipWith #-}
 
+#ifndef haskell98
 {-| Transform a 'Consumer' to a 'Pipe' that reforwards all values further
     downstream
 -}
@@ -708,3 +716,4 @@ generalize p x0 = evalStateP x0 $ up >\\ hoist lift p //> dn
         x <- respond a
         lift $ put x
 {-# INLINABLE generalize #-}
+#endif


### PR DESCRIPTION
I gave #102 a try.

I don't really like testing for `#ifdef MIN_VERSION_packagename` because it doesn't say anything to someone reading the code.

I would preffer if we could test for something like `#if !haskell98` ,  what do you think?

At first I thought that cabal will include the symbol defined by `Flag` in the auto generated header file but it does not. So the only good alternative would be to include our header file with our custom symbol defined.

Please tell me if this is what you wanted and if i've done it right. :-P

Thank you.
