### PR TITLE
Don't use Monad instance of transformed monad if not necessary.

### DIFF
--- a/src/Pipes/Lift.hs
+++ b/src/Pipes/Lift.hs
@@ -185,7 +185,7 @@ runStateP s p = (`S.runStateT` s) $ distribute p
 
 -- | Evaluate 'S.StateT' in the base monad
 evalStateP
-    :: Monad m
+    :: (Functor m,Monad m)
     => s
     -> Proxy a' a b' b (S.StateT s m) r
     -> Proxy a' a b' b m r
@@ -194,7 +194,7 @@ evalStateP s p = fmap fst $ runStateP s p
 
 -- | Execute 'S.StateT' in the base monad
 execStateP
-    :: Monad m
+    :: (Functor m,Monad m)
     => s
     -> Proxy a' a b' b (S.StateT s m) r
     -> Proxy a' a b' b m s
@@ -232,7 +232,7 @@ runWriterP p = W.runWriterT $ distribute p
 
 -- | Execute 'W.WriterT' in the base monad
 execWriterP
-    :: (Monad m, Monoid w)
+    :: (Functor m,Monad m, Monoid w)
     => Proxy a' a b' b (W.WriterT w m) r
     -> Proxy a' a b' b m w
 execWriterP p = fmap snd $ runWriterP p
@@ -265,7 +265,7 @@ runRWSP  i s p = (\b -> RWS.runRWST b i s) $ distribute p
 
 -- | Evaluate 'RWS.RWST' in the base monad
 evalRWSP
-    :: (Monad m, Monoid w)
+    :: (Functor m,Monad m, Monoid w)
     => r
     -> s
     -> Proxy a' a b' b (RWS.RWST r w s m) d
@@ -277,7 +277,7 @@ evalRWSP i s p = fmap f $ runRWSP i s p
 
 -- | Execute 'RWS.RWST' in the base monad
 execRWSP
-    :: (Monad m, Monoid w)
+    :: (Functor m,Monad m, Monoid w)
     => r
     -> s
     -> Proxy a' a b' b (RWS.RWST r w s m) d

--- a/src/Pipes/Prelude.hs
+++ b/src/Pipes/Prelude.hs
@@ -760,7 +760,7 @@ zipWith f = go
 {-| Transform a 'Consumer' to a 'Pipe' that reforwards all values further
     downstream
 -}
-tee :: Monad m => Consumer a m r -> Pipe a a m r
+tee :: (Functor m,Monad m) => Consumer a m r -> Pipe a a m r
 tee p = evalStateP Nothing $ do
     r <- up >\\ (hoist lift p //> dn)
     ma <- lift get
@@ -786,7 +786,7 @@ tee p = evalStateP Nothing $ do
 >
 > generalize cat = pull
 -}
-generalize :: Monad m => Pipe a b m r -> x -> Proxy x a x b m r
+generalize :: (Functor m,Monad m) => Pipe a b m r -> x -> Proxy x a x b m r
 generalize p x0 = evalStateP x0 $ up >\\ hoist lift p //> dn
   where
     up () = do


### PR DESCRIPTION
Hi, it would be nice if `(<*>)` would only use `(<*>)` of the underlying `Applicative` / `Monad`. Although the result should be the same, `(<*>)` sometimes has different performance characteristics, for example in [haxl](http://hackage.haskell.org/package/haxl).
