### PR TITLE
Remove some redundant Monad constraints

### DIFF
--- a/src/Pipes.hs
+++ b/src/Pipes.hs
@@ -130,7 +130,7 @@ f '~>' 'yield' = f
 'yield' :: 'Monad' m => a -> 'Pipe' x a m ()
 @
 -}
-yield :: Monad m => a -> Producer' a m ()
+yield :: a -> Producer' a m ()
 yield = respond
 {-# INLINABLE yield #-}
 
@@ -280,7 +280,7 @@ f '>~' 'await' = f
 'await' :: 'Monad' m => 'Pipe' a y m a
 @
 -}
-await :: Monad m => Consumer' a m a
+await :: Consumer' a m a
 await = request ()
 {-# INLINABLE await #-}
 
@@ -351,7 +351,7 @@ f '>->' 'cat' = f
 -}
 
 -- | The identity 'Pipe', analogous to the Unix @cat@ program
-cat :: Monad m => Pipe a a m r
+cat :: Pipe a a m r
 cat = pull ()
 {-# INLINABLE cat #-}
 

--- a/src/Pipes/Core.hs
+++ b/src/Pipes/Core.hs
@@ -278,7 +278,7 @@ f '/>/' 'respond' = f
 
     'respond' is the identity of the respond category.
 -}
-respond :: Monad m => a -> Proxy x' x a' a m a'
+respond :: a -> Proxy x' x a' a m a'
 respond a = Respond a Pure
 {-# INLINABLE respond #-}
 
@@ -410,7 +410,7 @@ f '\>\' 'request' = f
 
     'request' is the identity of the request category.
 -}
-request :: Monad m => a' -> Proxy a' a y' y m a
+request :: a' -> Proxy a' a y' y m a
 request a' = Request a' Pure
 {-# INLINABLE request #-}
 
@@ -528,7 +528,7 @@ f '>~>' 'push' = f
 
     'push' is the identity of the push category.
 -}
-push :: Monad m => a -> Proxy a' a a' a m r
+push :: a -> Proxy a' a a' a m r
 push = go
   where
     go a = Respond a (\a' -> Request a' go)
@@ -638,7 +638,7 @@ f '>+>' 'pull' = f
 
     'pull' is the identity of the pull category.
 -}
-pull :: Monad m => a' -> Proxy a' a a' a m r
+pull :: a' -> Proxy a' a a' a m r
 pull = go
   where
     go a' = Request a' (\a -> Respond a go)


### PR DESCRIPTION
None of the following require a `Monad` constraint, yet they had one in their type signatures: `yield`, `await`, `cat`, `request`, `respond`, `push`, `pull`.