### PR TITLE
Change takeWhile to return the failing element

### DIFF
--- a/src/Pipes/Prelude.hs
+++ b/src/Pipes/Prelude.hs
@@ -405,6 +405,25 @@ takeWhile predicate = go
             else return ()
 {-# INLINABLE takeWhile #-}
 
+{-| @(takeWhile' p)@ is a version of takeWhile that returns the value failing
+    the predicate.
+
+> takeWhile' (pure True) = cat
+>
+> takeWhile' (liftA2 (&&) p1 p2) = takeWhile' p1 >-> takeWhile' p2
+-}
+takeWhile' :: Monad m => (a -> Bool) -> Pipe a a m a
+takeWhile' predicate = go
+  where
+    go = do
+        a <- await
+        if (predicate a)
+            then do
+                yield a
+                go
+            else return a
+{-# INLINABLE takeWhile' #-}
+
 {-| @(drop n)@ discards @n@ values going downstream
 
 > drop 0 = cat


### PR DESCRIPTION
This gives pipelines a chance to hand the failing element downstream:

``` haskell
    runEffect $ for (each [1..10] >-> (P.takeWhile (<4) >>= yield >> cat)) $
        liftIO . Prelude.print
```

Otherwise, there is no way to make use of that element, neither to drop it, consume it, nor re-yield it.