### PR TITLE
add unfoldr

### DIFF
--- a/src/Pipes/Prelude.hs
+++ b/src/Pipes/Prelude.hs
@@ -27,6 +27,7 @@ module Pipes.Prelude (
     , fromHandle
     , repeatM
     , replicateM
+    , unfoldr
 
     -- * Consumers
     -- $consumers
@@ -900,3 +901,19 @@ generalize p x0 = evalStateP x0 $ up >\\ hoist lift p //> dn
         x <- respond a
         lift $ put x
 {-# INLINABLE generalize #-}
+
+{-| The natural unfold into a 'Producer' with a step function and a seed 
+
+> unfoldr next = id
+-}
+unfoldr :: Monad m 
+        => (s -> m (Either r (a, s))) -> s -> Producer a m r
+unfoldr step = loop where
+  loop s0 = do 
+    e <- lift (step s0)
+    case e of
+      Left r -> return r
+      Right (a,s) -> do 
+        yield a
+        loop s
+{-# INLINABLE unfoldr #-}


### PR DESCRIPTION
I was writing a replica of Pipes.Prelude for the obvious variant of `FreeT ((,) a) m r` and it was irritating that this could not be found.  See the dumb comments on the parallel function at

https://github.com/michaelt/streaming/blob/c3ee6d89c2a019a1b198b73edbd37e4d52cf3f3d/Streaming/Prelude.hs#L715

and the corresponding comments on 'next' and 'uncons'

https://github.com/michaelt/streaming/blob/c3ee6d89c2a019a1b198b73edbd37e4d52cf3f3d/Streaming/Prelude.hs

It is a slightly different issue, but it was seeming to me that it might be easy to get 'interoperation' for the Producer, Conduit.Source, IOStreams.InputStream types if they all exported a 'next' or 'uncons' .  The other natural way of 'translating' is via a natural fold or church encoding. But the 'fold' concept is in all these libraries understandably the strict-left-fold.  `conduit` and `io-streams` already export an `unfoldM` that corresponds to this `unfoldr` (but lacking a final return value and thus using maybe). I was thinking of trying to convince all the libraries to export an `uncons` or `next` so that they could be unfolded into each other.