### PR TITLE
optimize take and drop

### DIFF
--- a/src/Pipes/Prelude.hs
+++ b/src/Pipes/Prelude.hs
@@ -414,9 +414,12 @@ filterM predicate = for cat $ \a -> do
 > take (min m n) = take m >-> take n
 -}
 take :: Monad m => Int -> Pipe a a m ()
-take n = replicateM_ n $ do
+take = loop where
+  loop 0 = return () 
+  loop n = do 
     a <- await
     yield a
+    loop (n-1)
 {-# INLINABLE take #-}
 
 {-| @(takeWhile p)@ allows values to pass downstream so long as they satisfy
@@ -464,9 +467,12 @@ takeWhile' predicate = go
 > drop (m + n) = drop m >-> drop n
 -}
 drop :: Monad m => Int -> Pipe a a m r
-drop n = do
-    replicateM_ n await
-    cat
+drop = loop
+  where
+    loop 0 = cat
+    loop n =  do
+      await
+      loop (n-1)
 {-# INLINABLE drop #-}
 
 {-| @(dropWhile p)@ discards values going downstream until one violates the


### PR DESCRIPTION
This is not important but for some reason, the use of the imported `replicateM_` for `take` and `drop` impedes optimization.  I noticed this fiddling with some machines benchmarks of individual functions. See https://gist.github.com/michaelt/f19bef01423b17f29ffd The first list of results is hackage-pipes; the second is with these two repairs 


    benchmarking drop/conduit
     time                 26.56 ms   (26.31 ms .. 26.79 ms)
    benchmarking drop/pipes
     time                 43.64 ms   (42.48 ms .. 45.46 ms)

-- and with the modified drop:

    benchmarking drop/pipes
    time                 28.03 ms   (26.75 ms .. 29.67 ms)

Then 

    benchmarking take/conduit
    time                 45.38 ms   (44.57 ms .. 46.45 ms)
    benchmarking take/pipes
    time                 84.44 ms   (78.23 ms .. 91.36 ms)

and with the modified take: 

    benchmarking take/pipes
    time                 55.05 ms   (53.84 ms .. 56.26 ms)