### PR TITLE
canonicalise Monad instances

### DIFF
--- a/src/Pipes.hs
+++ b/src/Pipes.hs
@@ -408,7 +408,7 @@ instance (Monad m) => Applicative (ListT m) where
         yield (f x) ) ) )
 
 instance (Monad m) => Monad (ListT m) where
-    return a = Select (yield a)
+    return   = pure
     m >>= f  = Select (for (enumerate m) (\a -> enumerate (f a)))
     fail _   = mzero
 

--- a/src/Pipes/Internal.hs
+++ b/src/Pipes/Internal.hs
@@ -84,10 +84,10 @@ instance Monad m => Applicative (Proxy a' a b' b m) where
             Respond b  fb' -> Respond b  (\b' -> go (fb' b'))
             M          m   -> M (m >>= \p' -> return (go p'))
             Pure    f      -> fmap f px
-    (*>) = (>>)
+    m *> k = m >>= (\_ -> k)
 
 instance Monad m => Monad (Proxy a' a b' b m) where
-    return = Pure
+    return = pure
     (>>=)  = _bind
 
 _bind


### PR DESCRIPTION
This was detected via the new
`-fwarn-noncanonical-monad-instances` warning