### PR TITLE
Mention "All About Monads" to help with understanding transformers

### DIFF
--- a/src/Pipes/Tutorial.hs
+++ b/src/Pipes/Tutorial.hs
@@ -41,6 +41,8 @@
     learn about by reading either:
 
     * the paper \"Monad Transformers - Step by Step\",
+    
+    * part III \"Monads in the Real World\" of the tutorial \"All About Monads\",
 
     * chapter 18 of \"Real World Haskell\" on monad transformers, or:
 


### PR DESCRIPTION
It goes at a slower pace than "Monad Transformers - Step by Step", so for me as 
a Haskell beginner it was easier to understand. The chapters "Combining monads 
the hard way" and "Anatomy of a monad transformer" were particularly useful.