### PR TITLE
Delay inlining to allow rules to fire

### DIFF
--- a/benchmarks/Common.hs
+++ b/benchmarks/Common.hs
@@ -1,53 +1,19 @@
 module Common (commonMain) where
 
-import Criterion.Main (Benchmark, defaultMain)
+import Criterion.Main (Benchmark, runMode)
+import Criterion.Main.Options as Criterion
 import Data.Maybe (fromMaybe)
-import System.Console.GetOpt
-import System.Environment (getArgs, withArgs)
+import Options.Applicative
 
--- import Text.Read (readEither)
--- Switch to 'readEither' from "Text.Read" when Debian Stable uses base-4.6.0.0
-import Text.ParserCombinators.ReadP as P
-import Text.ParserCombinators.ReadPrec
-import Text.Read (readPrec)
-
-readEither :: Read a => String -> Either String a
-readEither s =
-  case [ x | (x,"") <- readPrec_to_S read' minPrec s ] of
-    [x] -> Right x
-    []  -> Left "Prelude.read: no parse"
-    _   -> Left "Prelude.read: ambiguous parse"
- where
-  read' =
-    do x <- readPrec
-       lift P.skipSpaces
-       return x
-
--- We request and extra Int parameter 'mdMax' so that
--- it is possible to have per module default benchmark
--- data size.
-commonMain :: Int -> (Int -> [Benchmark]) -> IO ()
+commonMain :: Int                    -- ^ default maximum data size
+           -> (Int -> [Benchmark])   -- ^ the benchmarks to run
+           -> IO ()
 commonMain mdMax bench = do
-    (maybeNewMax, critArgs) <- parseArgs =<< getArgs
-    
-    withArgs critArgs $ defaultMain $ bench $ fromMaybe mdMax maybeNewMax
+    (maybeNewMax, critMode) <- execParser $ info (helper <*> options) mempty
+    runMode critMode $ bench (fromMaybe mdMax maybeNewMax)
 
-options :: [OptDescr (Either String Int)]
+options :: Parser (Maybe Int, Criterion.Mode)
 options =
-    [
-      Option ['i'] ["imax"] (ReqArg readEither "vmax")
-      "Set benchmark maximum data size."
-    ]
-
-parseArgs :: [String] -> IO (Maybe Int, [String])
-parseArgs args =
-    case getOpt Permute options args of
-        ([], rst, [])   -> return (Nothing, rst)
-        ([ev], rst, []) -> either (usrErr prsErrMsg) (validate rst) ev
-        (_, _, errs)    -> usrErr "" $ concat errs
-    where
-        usrErr ce = ioError . userError . (++) ce
-        prsErrMsg = "-i requires a natural number >= 1 : "
-        validate rst v
-            | v >= 1 = return (Just v, rst)
-            | otherwise = usrErr prsErrMsg (show v)
+    (,) <$> optional (option auto (help "benchmark maximum data size"
+                                   <> metavar "N" <> short 'i'  <> long "imax"))
+        <*> Criterion.parseWith Criterion.defaultConfig

--- a/pipes.cabal
+++ b/pipes.cabal
@@ -66,7 +66,8 @@ Benchmark prelude-benchmarks
 
     Build-Depends:
         base      >= 4.4     && < 5  ,
-        criterion >= 0.6.2.1 && < 1.2,
+        criterion >= 1.1.1.0 && < 1.2,
+        optparse-applicative >= 0.12 && < 0.13,
         mtl       >= 2.1     && < 2.3,
         pipes     >= 4.0.0   && < 4.2
 
@@ -95,7 +96,8 @@ Benchmark lift-benchmarks
 
     Build-Depends:
         base         >= 4.4     && < 5  ,
-        criterion    >= 0.6.2.1 && < 1.2,
+        criterion    >= 1.1.1.0 && < 1.2,
+        optparse-applicative >= 0.12 && < 0.13,
         deepseq      >= 1.4.0.0         ,
         mtl          >= 2.1     && < 2.3,
         pipes        >= 4.0.0   && < 4.2,

--- a/pipes.cabal
+++ b/pipes.cabal
@@ -84,7 +84,7 @@ test-suite tests
         mtl                        >= 2.1     && < 2.3 ,
         test-framework             >= 0.4     && < 1   ,
         test-framework-quickcheck2 >= 0.2.0   && < 0.4 ,
-        transformers               >= 0.2.0.0 && < 0.5
+        transformers               >= 0.2.0.0 && < 0.6
 
 Benchmark lift-benchmarks
     Default-Language: Haskell2010
@@ -99,4 +99,4 @@ Benchmark lift-benchmarks
         deepseq      >= 1.4.0.0         ,
         mtl          >= 2.1     && < 2.3,
         pipes        >= 4.0.0   && < 4.2,
-        transformers >= 0.2.0.0 && < 0.5
+        transformers >= 0.2.0.0 && < 0.6

--- a/src/Pipes.hs
+++ b/src/Pipes.hs
@@ -132,7 +132,7 @@ f '~>' 'yield' = f
 -}
 yield :: Monad m => a -> Producer' a m ()
 yield = respond
-{-# INLINABLE yield #-}
+{-# INLINABLE [1] yield #-}
 
 {-| @(for p body)@ loops over @p@ replacing each 'yield' with @body@.
 
@@ -168,7 +168,7 @@ for :: Monad m
     -- ^
     ->       Proxy x' x c' c m a'
 for = (//>)
-{-# INLINABLE for #-}
+{-# INLINABLE [1] for #-}
 
 {-# RULES
     "for (for p f) g" forall p f g . for (for p f) g = for p (\a -> for (f a) g)
@@ -282,7 +282,7 @@ f '>~' 'await' = f
 -}
 await :: Monad m => Consumer' a m a
 await = request ()
-{-# INLINABLE await #-}
+{-# INLINABLE [1] await #-}
 
 {-| @(draw >~ p)@ loops over @p@ replacing each 'await' with @draw@
 
@@ -317,7 +317,7 @@ a ==>    f    ==> y   .--->   b ==>    g    ==> y     =     a ==>   f '>~' g  ==
     -- ^
     -> Proxy a' a y' y m c
 p1 >~ p2 = (\() -> p1) >\\ p2
-{-# INLINABLE (>~) #-}
+{-# INLINABLE [1] (>~) #-}
 
 -- | ('>~') with the arguments flipped
 (~<)
@@ -351,7 +351,7 @@ f '>->' 'cat' = f
 -- | The identity 'Pipe', analogous to the Unix @cat@ program
 cat :: Monad m => Pipe a a m r
 cat = pull ()
-{-# INLINABLE cat #-}
+{-# INLINABLE [1] cat #-}
 
 {-| 'Pipe' composition, analogous to the Unix pipe operator
 
@@ -386,7 +386,7 @@ a ==>    f    ==> b ==>    g    ==> c     =     a ==>  f '>->' g  ==> c
     -- ^
     -> Proxy a' a c' c m r
 p1 >-> p2 = (\() -> p1) +>> p2
-{-# INLINABLE (>->) #-}
+{-# INLINABLE [1] (>->) #-}
 
 {-| The list monad transformer, which extends a monad with non-determinism
 

--- a/src/Pipes.hs
+++ b/src/Pipes.hs
@@ -168,7 +168,10 @@ for :: Monad m
     -- ^
     ->       Proxy x' x c' c m a'
 for = (//>)
-{-# INLINABLE [1] for #-}
+-- There are a number of useful rewrites which can be performed on various uses
+-- of this combinator; to ensure that they fire we defer inlining until quite
+-- late.
+{-# INLINABLE [0] for #-}
 
 {-# RULES
     "for (for p f) g" forall p f g . for (for p f) g = for p (\a -> for (f a) g)

--- a/src/Pipes/Core.hs
+++ b/src/Pipes/Core.hs
@@ -320,7 +320,7 @@ p0 //> fb = go p0
         Respond b  fb' -> fb b >>= \b' -> go (fb' b')
         M          m   -> M (m >>= \p' -> return (go p'))
         Pure       a   -> Pure a
-{-# INLINABLE [1] (//>) #-}
+{-# INLINE [1] (//>) #-}
 
 {-# RULES
     "(Request x' fx ) //> fb" forall x' fx  fb .

--- a/src/Pipes/Core.hs
+++ b/src/Pipes/Core.hs
@@ -280,7 +280,7 @@ f '/>/' 'respond' = f
 -}
 respond :: Monad m => a -> Proxy x' x a' a m a'
 respond a = Respond a Pure
-{-# INLINABLE respond #-}
+{-# INLINABLE [1] respond #-}
 
 {-| Compose two unfolds, creating a new unfold
 
@@ -320,7 +320,7 @@ p0 //> fb = go p0
         Respond b  fb' -> fb b >>= \b' -> go (fb' b')
         M          m   -> M (m >>= \p' -> return (go p'))
         Pure       a   -> Pure a
-{-# INLINABLE (//>) #-}
+{-# INLINABLE [1] (//>) #-}
 
 {-# RULES
     "(Request x' fx ) //> fb" forall x' fx  fb .
@@ -412,7 +412,7 @@ f '\>\' 'request' = f
 -}
 request :: Monad m => a' -> Proxy a' a y' y m a
 request a' = Request a' Pure
-{-# INLINABLE request #-}
+{-# INLINABLE [1] request #-}
 
 {-| Compose two folds, creating a new fold
 
@@ -452,7 +452,7 @@ fb' >\\ p0 = go p0
         Respond x  fx' -> Respond x (\x' -> go (fx' x'))
         M          m   -> M (m >>= \p' -> return (go p'))
         Pure       a   -> Pure a
-{-# INLINABLE (>\\) #-}
+{-# INLINABLE [1] (>\\) #-}
 
 {-# RULES
     "fb' >\\ (Request b' fb )" forall fb' b' fb  .
@@ -532,7 +532,7 @@ push :: Monad m => a -> Proxy a' a a' a m r
 push = go
   where
     go a = Respond a (\a' -> Request a' go)
-{-# INLINABLE push #-}
+{-# INLINABLE [1] push #-}
 
 {-| Compose two proxies blocked while 'request'ing data, creating a new proxy
     blocked while 'request'ing data
@@ -571,7 +571,7 @@ p >>~ fb = case p of
     Respond b  fb' -> fb' +>> fb b
     M          m   -> M (m >>= \p' -> return (p' >>~ fb))
     Pure       r   -> Pure r
-{-# INLINABLE (>>~) #-}
+{-# INLINABLE [1] (>>~) #-}
 
 {- $pull
     The 'pull' category closely corresponds to pull-based Unix pipes.
@@ -642,7 +642,7 @@ pull :: Monad m => a' -> Proxy a' a a' a m r
 pull = go
   where
     go a' = Request a' (\a -> Respond a go)
-{-# INLINABLE pull #-}
+{-# INLINABLE [1] pull #-}
 
 {-| Compose two proxies blocked in the middle of 'respond'ing, creating a new
     proxy blocked in the middle of 'respond'ing
@@ -681,7 +681,7 @@ fb' +>> p = case p of
     Respond c  fc' -> Respond c (\c' -> fb' +>> fc' c')
     M          m   -> M (m >>= \p' -> return (fb' +>> p'))
     Pure       r   -> Pure r
-{-# INLINABLE (+>>) #-}
+{-# INLINABLE [1] (+>>) #-}
 
 {- $reflect
     @(reflect .)@ transforms each streaming category into its dual:

--- a/src/Pipes/Core.hs
+++ b/src/Pipes/Core.hs
@@ -452,7 +452,7 @@ fb' >\\ p0 = go p0
         Respond x  fx' -> Respond x (\x' -> go (fx' x'))
         M          m   -> M (m >>= \p' -> return (go p'))
         Pure       a   -> Pure a
-{-# INLINABLE [1] (>\\) #-}
+{-# INLINE [1] (>\\) #-}
 
 {-# RULES
     "fb' >\\ (Request b' fb )" forall fb' b' fb  .
@@ -571,7 +571,7 @@ p >>~ fb = case p of
     Respond b  fb' -> fb' +>> fb b
     M          m   -> M (m >>= \p' -> return (p' >>~ fb))
     Pure       r   -> Pure r
-{-# INLINABLE [1] (>>~) #-}
+{-# INLINE [1] (>>~) #-}
 
 {- $pull
     The 'pull' category closely corresponds to pull-based Unix pipes.

--- a/src/Pipes/Internal.hs
+++ b/src/Pipes/Internal.hs
@@ -102,12 +102,6 @@ p0 `_bind` f = go p0 where
         M          m   -> M (m >>= \p' -> return (go p'))
         Pure    r      -> f r
 
--- While inlining this would allow us to specialise to the Monad m
--- dictionary, this generally isn't enough of a win to warrant the
--- code bloat that it induces. Moreover, inlining this (even only in phase 0)
--- appears to regress the Pipes/concat benchmark.
-{-# NOINLINE _bind #-}
-
 {-# RULES
     "_bind (Request a' k) f" forall a' k f .
         _bind (Request a' k) f = Request a' (\a  -> _bind (k a)  f);

--- a/src/Pipes/Internal.hs
+++ b/src/Pipes/Internal.hs
@@ -102,6 +102,12 @@ p0 `_bind` f = go p0 where
         M          m   -> M (m >>= \p' -> return (go p'))
         Pure    r      -> f r
 
+-- While inlining this would allow us to specialise to the Monad m
+-- dictionary, this generally isn't enough of a win to warrant the
+-- code bloat that it induces. Moreover, inlining this (even only in phase 0)
+-- appears to regress the Pipes/concat benchmark.
+{-# NOINLINE _bind #-}
+
 {-# RULES
     "_bind (Request a' k) f" forall a' k f .
         _bind (Request a' k) f = Request a' (\a  -> _bind (k a)  f);

--- a/src/Pipes/Prelude.hs
+++ b/src/Pipes/Prelude.hs
@@ -101,7 +101,7 @@ module Pipes.Prelude (
     ) where
 
 import Control.Exception (throwIO, try)
-import Control.Monad (liftM, replicateM_, when, unless)
+import Control.Monad (liftM, when, unless)
 import Control.Monad.Trans.State.Strict (get, put)
 import Data.Functor.Identity (Identity, runIdentity)
 import Foreign.C.Error (Errno(Errno), ePIPE)

--- a/src/Pipes/Prelude.hs
+++ b/src/Pipes/Prelude.hs
@@ -196,7 +196,7 @@ fromHandle h = go
 -- | Repeat a monadic action indefinitely, 'yield'ing each result
 repeatM :: Monad m => m a -> Producer' a m r
 repeatM m = lift m >~ cat
-{-# INLINABLE repeatM #-}
+{-# INLINABLE [1] repeatM #-}
 
 {-# RULES
   "repeatM m >-> p" forall m p . repeatM m >-> p = lift m >~ p
@@ -250,7 +250,7 @@ stdoutLn = go
 -}
 stdoutLn' :: MonadIO m => Consumer' String m r
 stdoutLn' = for cat (\str -> liftIO (putStrLn str))
-{-# INLINABLE stdoutLn' #-}
+{-# INLINABLE [1] stdoutLn' #-}
 
 {-# RULES
     "p >-> stdoutLn'" forall p .
@@ -260,7 +260,7 @@ stdoutLn' = for cat (\str -> liftIO (putStrLn str))
 -- | Consume all values using a monadic function
 mapM_ :: Monad m => (a -> m ()) -> Consumer' a m r
 mapM_ f = for cat (\a -> lift (f a))
-{-# INLINABLE mapM_ #-}
+{-# INLINABLE [1] mapM_ #-}
 
 {-# RULES
     "p >-> mapM_ f" forall p f .
@@ -270,7 +270,7 @@ mapM_ f = for cat (\a -> lift (f a))
 -- | 'print' values to 'IO.stdout'
 print :: (MonadIO m, Show a) => Consumer' a m r
 print = for cat (\a -> liftIO (Prelude.print a))
-{-# INLINABLE print #-}
+{-# INLINABLE [1] print #-}
 
 {-# RULES
     "p >-> print" forall p .
@@ -280,7 +280,7 @@ print = for cat (\a -> liftIO (Prelude.print a))
 -- | Write 'String's to a 'IO.Handle' using 'IO.hPutStrLn'
 toHandle :: MonadIO m => IO.Handle -> Consumer' String m r
 toHandle handle = for cat (\str -> liftIO (IO.hPutStrLn handle str))
-{-# INLINABLE toHandle #-}
+{-# INLINABLE [1] toHandle #-}
 
 {-# RULES
     "p >-> toHandle handle" forall p handle .
@@ -290,7 +290,7 @@ toHandle handle = for cat (\str -> liftIO (IO.hPutStrLn handle str))
 -- | 'discard' all incoming values
 drain :: Monad m => Consumer' a m r
 drain = for cat discard
-{-# INLINABLE drain #-}
+{-# INLINABLE [1] drain #-}
 
 {-# RULES
     "p >-> drain" forall p .
@@ -318,7 +318,7 @@ quit<Enter>
 -}
 map :: Monad m => (a -> b) -> Pipe a b m r
 map f = for cat (\a -> yield (f a))
-{-# INLINABLE map #-}
+{-# INLINABLE [1] map #-}
 
 {-# RULES
     "p >-> map f" forall p f . p >-> map f = for p (\a -> yield (f a))
@@ -338,7 +338,7 @@ mapM :: Monad m => (a -> m b) -> Pipe a b m r
 mapM f = for cat $ \a -> do
     b <- lift (f a)
     yield b
-{-# INLINABLE mapM #-}
+{-# INLINABLE [1] mapM #-}
 
 {-# RULES
     "p >-> mapM f" forall p f . p >-> mapM f = for p (\a -> do
@@ -361,7 +361,7 @@ sequence = mapM id
 -}
 mapFoldable :: (Monad m, Foldable t) => (a -> t b) -> Pipe a b m r
 mapFoldable f = for cat (\a -> each (f a))
-{-# INLINABLE mapFoldable #-}
+{-# INLINABLE [1] mapFoldable #-}
 
 {-# RULES
     "p >-> mapFoldable f" forall p f .
@@ -376,7 +376,7 @@ mapFoldable f = for cat (\a -> each (f a))
 -}
 filter :: Monad m => (a -> Bool) -> Pipe a a m r
 filter predicate = for cat $ \a -> when (predicate a) (yield a)
-{-# INLINABLE filter #-}
+{-# INLINABLE [1] filter #-}
 
 {-# RULES
     "p >-> filter predicate" forall p predicate.
@@ -394,7 +394,7 @@ filterM :: Monad m => (a -> m Bool) -> Pipe a a m r
 filterM predicate = for cat $ \a -> do
     b <- lift (predicate a)
     when b (yield a)
-{-# INLINABLE filterM #-}
+{-# INLINABLE [1] filterM #-}
 
 {-# RULES
     "p >-> filterM predicate" forall p predicate .
@@ -497,7 +497,7 @@ dropWhile predicate = go
 -- | Flatten all 'Foldable' elements flowing downstream
 concat :: (Monad m, Foldable f) => Pipe (f a) a m r
 concat = for cat each
-{-# INLINABLE concat #-}
+{-# INLINABLE [1] concat #-}
 
 {-# RULES
     "p >-> concat" forall p . p >-> concat = for p each
@@ -559,7 +559,7 @@ chain :: Monad m => (a -> m ()) -> Pipe a a m r
 chain f = for cat $ \a -> do
     lift (f a)
     yield a
-{-# INLINABLE chain #-}
+{-# INLINABLE [1] chain #-}
 
 {-# RULES
     "p >-> chain f" forall p f .
@@ -578,7 +578,7 @@ read :: (Monad m, Read a) => Pipe String a m r
 read = for cat $ \str -> case (reads str) of
     [(a, "")] -> yield a
     _         -> return ()
-{-# INLINABLE read #-}
+{-# INLINABLE [1] read #-}
 
 {-# RULES
     "p >-> read" forall p .


### PR DESCRIPTION
The rewrite rules defined in Pipes are currently quite fragile as the
functions which they match on may be inlined before the rules are given
an opportunity to fire. Here we delay inlining of various operations to ensure that the rules can fire
unimpeded during simplifier phase 2.

These cases are pointed out by a warning which will be introduced in GHC 8.0.1.