### PR TITLE
Add Common.hs to other-modules in benchmarks

### DIFF
--- a/pipes.cabal
+++ b/pipes.cabal
@@ -62,6 +62,7 @@ Benchmark prelude-benchmarks
     Type:             exitcode-stdio-1.0
     HS-Source-Dirs:   benchmarks
     Main-Is:          PreludeBench.hs
+    Other-Modules:    Common
     GHC-Options:     -O2 -Wall -rtsopts -fno-warn-unused-do-bind
 
     Build-Depends:
@@ -91,6 +92,7 @@ Benchmark lift-benchmarks
     Type:             exitcode-stdio-1.0
     HS-Source-Dirs:   benchmarks
     Main-Is:          LiftBench.hs
+    Other-Modules:    Common
     GHC-Options:     -O2 -Wall -rtsopts -fno-warn-unused-do-bind
 
     Build-Depends:


### PR DESCRIPTION
Currently, `pipes`' benchmarks fail to build on Hackage since `Common` isn't listed as `other-modules` of the benchmarks, which means `cabal sdist` doesn't package up `Common.hs` with the tarball.

See also https://github.com/fpco/stackage/issues/1372