### PR TITLE
Add evalListT to get results from ListT as a list

### DIFF
--- a/src/Pipes.hs
+++ b/src/Pipes.hs
@@ -574,7 +574,7 @@ evalListT :: Monad m => ListT m a -> m [a]
 evalListT listT =
       runEffect
   $   execWriterP
-  $   (writerP $ (\() -> ((), [])) <$> (enumerate $ listT >> mzero))
+  $   (writerP $ (\() -> ((), [])) <$> enumerate listT)
   >-> (M.forever $ pass ((\element -> ((), (element :))) <$> await))
 
 {-| 'Enumerable' generalizes 'Data.Foldable.Foldable', converting effectful


### PR DESCRIPTION
The proper way to use `ListT` in pipes is to have an underlying monad and effect per choice through that monad. However, sometimes it's really convenient to run a `ListT` computation and then get the results in the underlying monad as a list. Since the MTL's `ListT` is more restrictive, many use cases for this functionality would be helped by using pipes' `ListT`, while still obtaining the results as a list.