### PR TITLE
Fix `pass` in `MonadWriter` instance

### DIFF
--- a/src/Pipes/Internal.hs
+++ b/src/Pipes/Internal.hs
@@ -41,7 +41,7 @@ import Control.Monad.Except (MonadError(..))
 import Control.Monad.Catch (MonadThrow(..), MonadCatch(..))
 import Control.Monad.Reader (MonadReader(..))
 import Control.Monad.State (MonadState(..))
-import Control.Monad.Writer (MonadWriter(..))
+import Control.Monad.Writer (MonadWriter(..), censor)
 import Data.Void (Void)
 
 #if MIN_VERSION_base(4,8,0)
@@ -211,7 +211,7 @@ instance MonadWriter w m => MonadWriter w (Proxy a' a b' b m) where
             Request a' fa  -> Request a' (\a  -> go (fa  a ) w)
             Respond b  fb' -> Respond b  (\b' -> go (fb' b') w)
             M       m      -> M (do
-                (p', w') <- listen m
+                (p', w') <- censor (const mempty) (listen m)
                 return (go p' $! mappend w w') )
             Pure   (r, f)  -> M (pass (return (Pure r, \_ -> f w)))
 


### PR DESCRIPTION
Previous version would accumulate the entire log unchanged, and then
append a modified version at the end; the new one removes the old log
entries by replacing them with `mempty`.

Here's an example (any `execWriter` from mtl):

```haskell
execWriter $ runEffect $ pass $ tell [1] >> pure ((), (2:))
```

Previously, this would evaluate to `[1,2,1]` (old log + modified old
log); now, it evaluates to `[2,1]`, same as when using just `WriterT`.