### PR TITLE
Relax Monad constraints to Functor

### DIFF
--- a/src/Pipes.hs
+++ b/src/Pipes.hs
@@ -136,17 +136,17 @@ f '~>' 'yield' = f
 'yield' :: 'Monad' m => a -> 'Pipe' x a m ()
 @
 -}
-yield :: Monad m => a -> Producer' a m ()
+yield :: Functor m => a -> Producer' a m ()
 yield = respond
 {-# INLINABLE [1] yield #-}
 
 {-| @(for p body)@ loops over @p@ replacing each 'yield' with @body@.
 
 @
-'for' :: 'Monad' m => 'Producer' b m r -> (b -> 'Effect'       m ()) -> 'Effect'       m r
-'for' :: 'Monad' m => 'Producer' b m r -> (b -> 'Producer'   c m ()) -> 'Producer'   c m r
-'for' :: 'Monad' m => 'Pipe'   x b m r -> (b -> 'Consumer' x   m ()) -> 'Consumer' x   m r
-'for' :: 'Monad' m => 'Pipe'   x b m r -> (b -> 'Pipe'     x c m ()) -> 'Pipe'     x c m r
+'for' :: 'Functor' m => 'Producer' b m r -> (b -> 'Effect'       m ()) -> 'Effect'       m r
+'for' :: 'Functor' m => 'Producer' b m r -> (b -> 'Producer'   c m ()) -> 'Producer'   c m r
+'for' :: 'Functor' m => 'Pipe'   x b m r -> (b -> 'Consumer' x   m ()) -> 'Consumer' x   m r
+'for' :: 'Functor' m => 'Pipe'   x b m r -> (b -> 'Pipe'     x c m ()) -> 'Pipe'     x c m r
 @
 
     The following diagrams show the flow of information:
@@ -167,7 +167,7 @@ x ==>    p    ==> b   ---'   x ==>   body  ==> c     =     x ==> 'for' p body  =
 
     For a more complete diagram including bidirectional flow, see "Pipes.Core#respond-diagram".
 -}
-for :: Monad m
+for :: Functor m
     =>       Proxy x' x b' b m a'
     -- ^
     -> (b -> Proxy x' x c' c m b')
@@ -220,10 +220,10 @@ for = (//>)
 {-| Compose loop bodies
 
 @
-('~>') :: 'Monad' m => (a -> 'Producer' b m r) -> (b -> 'Effect'       m ()) -> (a -> 'Effect'       m r)
-('~>') :: 'Monad' m => (a -> 'Producer' b m r) -> (b -> 'Producer'   c m ()) -> (a -> 'Producer'   c m r)
-('~>') :: 'Monad' m => (a -> 'Pipe'   x b m r) -> (b -> 'Consumer' x   m ()) -> (a -> 'Consumer' x   m r)
-('~>') :: 'Monad' m => (a -> 'Pipe'   x b m r) -> (b -> 'Pipe'     x c m ()) -> (a -> 'Pipe'     x c m r)
+('~>') :: 'Functor' m => (a -> 'Producer' b m r) -> (b -> 'Effect'       m ()) -> (a -> 'Effect'       m r)
+('~>') :: 'Functor' m => (a -> 'Producer' b m r) -> (b -> 'Producer'   c m ()) -> (a -> 'Producer'   c m r)
+('~>') :: 'Functor' m => (a -> 'Pipe'   x b m r) -> (b -> 'Consumer' x   m ()) -> (a -> 'Consumer' x   m r)
+('~>') :: 'Functor' m => (a -> 'Pipe'   x b m r) -> (b -> 'Pipe'     x c m ()) -> (a -> 'Pipe'     x c m r)
 @
 
     The following diagrams show the flow of information:
@@ -245,7 +245,7 @@ x ==>    f    ==> b   ---'   x ==>    g    ==> c     =     x ==>   f '~>' g  ==>
     For a more complete diagram including bidirectional flow, see "Pipes.Core#respond-diagram".
 -}
 (~>)
-    :: Monad m
+    :: Functor m
     => (a -> Proxy x' x b' b m a')
     -- ^
     -> (b -> Proxy x' x c' c m b')
@@ -256,7 +256,7 @@ x ==>    f    ==> b   ---'   x ==>    g    ==> c     =     x ==>   f '~>' g  ==>
 
 -- | ('~>') with the arguments flipped
 (<~)
-    :: Monad m
+    :: Functor m
     => (b -> Proxy x' x c' c m b')
     -- ^
     -> (a -> Proxy x' x b' b m a')
@@ -286,20 +286,20 @@ f '>~' 'await' = f
 {-| Consume a value
 
 @
-'await' :: 'Monad' m => 'Pipe' a y m a
+'await' :: 'Functor' m => 'Pipe' a y m a
 @
 -}
-await :: Monad m => Consumer' a m a
+await :: Functor m => Consumer' a m a
 await = request ()
 {-# INLINABLE [1] await #-}
 
 {-| @(draw >~ p)@ loops over @p@ replacing each 'await' with @draw@
 
 @
-('>~') :: 'Monad' m => 'Effect'       m b -> 'Consumer' b   m c -> 'Effect'       m c
-('>~') :: 'Monad' m => 'Consumer' a   m b -> 'Consumer' b   m c -> 'Consumer' a   m c
-('>~') :: 'Monad' m => 'Producer'   y m b -> 'Pipe'     b y m c -> 'Producer'   y m c
-('>~') :: 'Monad' m => 'Pipe'     a y m b -> 'Pipe'     b y m c -> 'Pipe'     a y m c
+('>~') :: 'Functor' m => 'Effect'       m b -> 'Consumer' b   m c -> 'Effect'       m c
+('>~') :: 'Functor' m => 'Consumer' a   m b -> 'Consumer' b   m c -> 'Consumer' a   m c
+('>~') :: 'Functor' m => 'Producer'   y m b -> 'Pipe'     b y m c -> 'Producer'   y m c
+('>~') :: 'Functor' m => 'Pipe'     a y m b -> 'Pipe'     b y m c -> 'Pipe'     a y m c
 @
 
     The following diagrams show the flow of information:
@@ -319,7 +319,7 @@ a ==>    f    ==> y   .--->   b ==>    g    ==> y     =     a ==>   f '>~' g  ==
     For a more complete diagram including bidirectional flow, see "Pipes.Core#request-diagram".
 -}
 (>~)
-    :: Monad m
+    :: Functor m
     => Proxy a' a y' y m b
     -- ^
     -> Proxy () b y' y m c
@@ -330,7 +330,7 @@ p1 >~ p2 = (\() -> p1) >\\ p2
 
 -- | ('>~') with the arguments flipped
 (~<)
-    :: Monad m
+    :: Functor m
     => Proxy () b y' y m c
     -- ^
     -> Proxy a' a y' y m b
@@ -358,17 +358,17 @@ f '>->' 'cat' = f
 -}
 
 -- | The identity 'Pipe', analogous to the Unix @cat@ program
-cat :: Monad m => Pipe a a m r
+cat :: Functor m => Pipe a a m r
 cat = pull ()
 {-# INLINABLE [1] cat #-}
 
 {-| 'Pipe' composition, analogous to the Unix pipe operator
 
 @
-('>->') :: 'Monad' m => 'Producer' b m r -> 'Consumer' b   m r -> 'Effect'       m r
-('>->') :: 'Monad' m => 'Producer' b m r -> 'Pipe'     b c m r -> 'Producer'   c m r
-('>->') :: 'Monad' m => 'Pipe'   a b m r -> 'Consumer' b   m r -> 'Consumer' a   m r
-('>->') :: 'Monad' m => 'Pipe'   a b m r -> 'Pipe'     b c m r -> 'Pipe'     a c m r
+('>->') :: 'Functor' m => 'Producer' b m r -> 'Consumer' b   m r -> 'Effect'       m r
+('>->') :: 'Functor' m => 'Producer' b m r -> 'Pipe'     b c m r -> 'Producer'   c m r
+('>->') :: 'Functor' m => 'Pipe'   a b m r -> 'Consumer' b   m r -> 'Consumer' a   m r
+('>->') :: 'Functor' m => 'Pipe'   a b m r -> 'Pipe'     b c m r -> 'Pipe'     a c m r
 @
 
     The following diagrams show the flow of information:
@@ -388,7 +388,7 @@ a ==>    f    ==> b ==>    g    ==> c     =     a ==>  f '>->' g  ==> c
     For a more complete diagram including bidirectional flow, see "Pipes.Core#pull-diagram".
 -}
 (>->)
-    :: Monad m
+    :: Functor m
     => Proxy a' a () b m r
     -- ^
     -> Proxy () b c' c m r
@@ -406,11 +406,11 @@ p1 >-> p2 = (\() -> p1) +>> p2
 -}
 newtype ListT m a = Select { enumerate :: Producer a m () }
 
-instance Monad m => Functor (ListT m) where
+instance Functor m => Functor (ListT m) where
     fmap f p = Select (for (enumerate p) (\a -> yield (f a)))
     {-# INLINE fmap #-}
 
-instance Monad m => Applicative (ListT m) where
+instance Functor m => Applicative (ListT m) where
     pure a = Select (yield a)
     {-# INLINE pure #-}
     mf <*> mx = Select (
@@ -436,7 +436,7 @@ instance Foldable m => Foldable (ListT m) where
             Pure    _    -> mempty
     {-# INLINE foldMap #-}
 
-instance (Monad m, Traversable m) => Traversable (ListT m) where
+instance (Functor m, Traversable m) => Traversable (ListT m) where
     traverse k (Select p) = fmap Select (traverse_ p)
       where
         traverse_ (Request v _ ) = closed v
@@ -455,7 +455,7 @@ instance (MonadIO m) => MonadIO (ListT m) where
     liftIO m = lift (liftIO m)
     {-# INLINE liftIO #-}
 
-instance (Monad m) => Alternative (ListT m) where
+instance (Functor m) => Alternative (ListT m) where
     empty = Select (return ())
     {-# INLINE empty #-}
     p1 <|> p2 = Select (do
@@ -481,11 +481,11 @@ instance MMonad ListT where
         loop (Pure    r     ) = Pure r
     {-# INLINE embed #-}
 
-instance (Monad m) => Semigroup (ListT m a) where
+instance (Functor m) => Semigroup (ListT m a) where
     (<>) = (<|>)
     {-# INLINE (<>) #-}
 
-instance (Monad m) => Monoid (ListT m a) where
+instance (Functor m) => Monoid (ListT m a) where
     mempty = empty
     {-# INLINE mempty #-}
 #if !(MIN_VERSION_base(4,11,0))
@@ -629,7 +629,7 @@ next = go
 {-# INLINABLE next #-}
 
 -- | Convert a 'F.Foldable' to a 'Producer'
-each :: (Monad m, Foldable f) => f a -> Producer' a m ()
+each :: (Functor m, Foldable f) => f a -> Producer' a m ()
 each = F.foldr (\a p -> yield a >> p) (return ())
 {-# INLINABLE each #-}
 {-  The above code is the same as:
@@ -652,7 +652,7 @@ discard _ = return ()
 
 -- | ('>->') with the arguments flipped
 (<-<)
-    :: Monad m
+    :: Functor m
     => Proxy () b c' c m r
     -- ^
     -> Proxy a' a () b m r

--- a/src/Pipes/Lift.hs
+++ b/src/Pipes/Lift.hs
@@ -97,7 +97,7 @@ runExceptP
     :: Monad m
     => Proxy a' a b' b (E.ExceptT e m) r
     -> Proxy a' a b' b m (Either e r)
-runExceptP    = E.runExceptT . distribute 
+runExceptP    = E.runExceptT . distribute
 {-# INLINABLE runExceptP #-}
 
 -- | Catch an error in the base monad

--- a/src/Pipes/Prelude.hs
+++ b/src/Pipes/Prelude.hs
@@ -289,7 +289,7 @@ toHandle handle = for cat (\str -> liftIO (IO.hPutStrLn handle str))
   #-}
 
 -- | 'discard' all incoming values
-drain :: Monad m => Consumer' a m r
+drain :: Functor m => Consumer' a m r
 drain = for cat discard
 {-# INLINABLE [1] drain #-}
 
@@ -317,7 +317,7 @@ quit<Enter>
 >
 > map (g . f) = map f >-> map g
 -}
-map :: Monad m => (a -> b) -> Pipe a b m r
+map :: Functor m => (a -> b) -> Pipe a b m r
 map f = for cat (\a -> yield (f a))
 {-# INLINABLE [1] map #-}
 
@@ -360,7 +360,7 @@ sequence = mapM id
 {- | Apply a function to all values flowing downstream, and
      forward each element of the result.
 -}
-mapFoldable :: (Monad m, Foldable t) => (a -> t b) -> Pipe a b m r
+mapFoldable :: (Functor m, Foldable t) => (a -> t b) -> Pipe a b m r
 mapFoldable f = for cat (\a -> each (f a))
 {-# INLINABLE [1] mapFoldable #-}
 
@@ -375,7 +375,7 @@ mapFoldable f = for cat (\a -> each (f a))
 >
 > filter (liftA2 (&&) p1 p2) = filter p1 >-> filter p2
 -}
-filter :: Monad m => (a -> Bool) -> Pipe a a m r
+filter :: Functor m => (a -> Bool) -> Pipe a a m r
 filter predicate = for cat $ \a -> when (predicate a) (yield a)
 {-# INLINABLE [1] filter #-}
 
@@ -414,7 +414,7 @@ filterM predicate = for cat $ \a -> do
 >
 > take (min m n) = take m >-> take n
 -}
-take :: Monad m => Int -> Pipe a a m ()
+take :: Functor m => Int -> Pipe a a m ()
 take = go
   where
     go 0 = return () 
@@ -431,7 +431,7 @@ take = go
 >
 > takeWhile (liftA2 (&&) p1 p2) = takeWhile p1 >-> takeWhile p2
 -}
-takeWhile :: Monad m => (a -> Bool) -> Pipe a a m ()
+takeWhile :: Functor m => (a -> Bool) -> Pipe a a m ()
 takeWhile predicate = go
   where
     go = do
@@ -450,7 +450,7 @@ takeWhile predicate = go
 >
 > takeWhile' (liftA2 (&&) p1 p2) = takeWhile' p1 >-> takeWhile' p2
 -}
-takeWhile' :: Monad m => (a -> Bool) -> Pipe a a m a
+takeWhile' :: Functor m => (a -> Bool) -> Pipe a a m a
 takeWhile' predicate = go
   where
     go = do
@@ -468,7 +468,7 @@ takeWhile' predicate = go
 >
 > drop (m + n) = drop m >-> drop n
 -}
-drop :: Monad m => Int -> Pipe a a m r
+drop :: Functor m => Int -> Pipe a a m r
 drop = go
   where
     go 0 = cat
@@ -484,7 +484,7 @@ drop = go
 >
 > dropWhile (liftA2 (||) p1 p2) = dropWhile p1 >-> dropWhile p2
 -}
-dropWhile :: Monad m => (a -> Bool) -> Pipe a a m r
+dropWhile :: Functor m => (a -> Bool) -> Pipe a a m r
 dropWhile predicate = go
   where
     go = do
@@ -497,7 +497,7 @@ dropWhile predicate = go
 {-# INLINABLE dropWhile #-}
 
 -- | Flatten all 'Foldable' elements flowing downstream
-concat :: (Monad m, Foldable f) => Pipe (f a) a m r
+concat :: (Functor m, Foldable f) => Pipe (f a) a m r
 concat = for cat each
 {-# INLINABLE [1] concat #-}
 
@@ -506,12 +506,12 @@ concat = for cat each
   #-}
 
 -- | Outputs the indices of all elements that match the given element
-elemIndices :: (Monad m, Eq a) => a -> Pipe a Int m r
+elemIndices :: (Functor m, Eq a) => a -> Pipe a Int m r
 elemIndices a = findIndices (a ==)
 {-# INLINABLE elemIndices #-}
 
 -- | Outputs the indices of all elements that satisfied the predicate
-findIndices :: Monad m => (a -> Bool) -> Pipe a Int m r
+findIndices :: Functor m => (a -> Bool) -> Pipe a Int m r
 findIndices predicate = go 0
   where
     go n = do
@@ -524,7 +524,7 @@ findIndices predicate = go 0
 
 > Control.Foldl.purely scan :: Monad m => Fold a b -> Pipe a b m r
 -}
-scan :: Monad m => (x -> a -> x) -> x -> (x -> b) -> Pipe a b m r
+scan :: Functor m => (x -> a -> x) -> x -> (x -> b) -> Pipe a b m r
 scan step begin done = go begin
   where
     go x = do
@@ -576,7 +576,7 @@ chain f = for cat $ \a -> do
   #-}
 
 -- | Parse 'Read'able values, only forwarding the value if the parse succeeds
-read :: (Monad m, Read a) => Pipe String a m r
+read :: (Functor m, Read a) => Pipe String a m r
 read = for cat $ \str -> case (reads str) of
     [(a, "")] -> yield a
     _         -> return ()
@@ -590,12 +590,12 @@ read = for cat $ \str -> case (reads str) of
   #-}
 
 -- | Convert 'Show'able values to 'String's
-show :: (Monad m, Show a) => Pipe a String m r
+show :: (Functor m, Show a) => Pipe a String m r
 show = map Prelude.show
 {-# INLINABLE show #-}
 
 -- | Evaluate all values flowing downstream to WHNF
-seq :: Monad m => Pipe a a m r
+seq :: Functor m => Pipe a a m r
 seq = for cat $ \a -> yield $! a
 {-# INLINABLE seq #-}
 


### PR DESCRIPTION
This relaxes the Monad constraint for many functions using **Proxy** to Functor, throughout the library. The main places where this isn't possible are anything involving `runEffect`, or using `MonadTrans`, since `lift` requires a Monad constraint.
I also haven't touched the Tutorial module, because I'm not sure that it would make explaining things much easier to swap between Functor and Monad constraints.