### PR TITLE
Update base lower bound so that we don't try to build on GHC < 7.10

### DIFF
--- a/pipes.cabal
+++ b/pipes.cabal
@@ -46,7 +46,7 @@ Library
 
     HS-Source-Dirs: src
     Build-Depends:
-        base         >= 4.4     && < 5   ,
+        base         >= 4.8     && < 5   ,
         transformers >= 0.2.0.0 && < 0.6 ,
         exceptions   >= 0.4     && < 0.11,
         mmorph       >= 1.0.0   && < 1.2 ,


### PR DESCRIPTION
This package doesn't build on GHC 7.8 or below today. This PR makes the base lower bound reflect that.

Alternatively, I think we could change the code to support below GHC 7.10 by doing things like replacing `<$>` with `liftM` and tweaking some constraints. If I wrote that pull request instead, would you be interested in that?