### PR TITLE
Increase lower bound for mmorph to 1.0.4

### DIFF
--- a/pipes.cabal
+++ b/pipes.cabal
@@ -49,7 +49,7 @@ Library
         base         >= 4.8     && < 5   ,
         transformers >= 0.2.0.0 && < 0.6 ,
         exceptions   >= 0.4     && < 0.11,
-        mmorph       >= 1.0.0   && < 1.2 ,
+        mmorph       >= 1.0.4   && < 1.2 ,
         mtl          >= 2.2.1   && < 2.3 ,
         void         >= 0.4     && < 0.8 ,
         semigroups   >= 0.17    && < 0.19


### PR DESCRIPTION
`Pipes.Lift` is using `MFunctor (ExceptT e)` instances which were
added to mmorph in 1.0.4