### PR TITLE
Correct documentation of scanM

### DIFF
--- a/src/Pipes/Prelude.hs
+++ b/src/Pipes/Prelude.hs
@@ -536,7 +536,7 @@ scan step begin done = go begin
 
 {-| Strict, monadic left scan
 
-> Control.Foldl.impurely scan :: Monad m => FoldM a m b -> Pipe a b m r
+> Control.Foldl.impurely scanM :: Monad m => FoldM m a b -> Pipe a b m r
 -}
 scanM :: Monad m => (x -> a -> m x) -> m x -> (x -> m b) -> Pipe a b m r
 scanM step begin done = do


### PR DESCRIPTION
I'm guessing this is what it was meant to say, looks like a copy/paste issue from the `scan` documentation.