### PR TITLE
Fix space leak when using `forever`

### DIFF
--- a/src/Pipes/Internal.hs
+++ b/src/Pipes/Internal.hs
@@ -90,6 +90,12 @@ instance Functor m => Applicative (Proxy a' a b' b m) where
             Respond b  fb' -> Respond b  (\b' -> go (fb' b'))
             M          m   -> M (go <$> m)
             Pure    f      -> fmap f px
+    l *> r = go l where
+        go p = case p of
+            Request a' fa  -> Request a' (\a  -> go (fa  a ))
+            Respond b  fb' -> Respond b  (\b' -> go (fb' b'))
+            M          m   -> M (go <$> m)
+            Pure    _      -> r
 
 instance Functor m => Monad (Proxy a' a b' b m) where
     return = pure


### PR DESCRIPTION
Related to https://github.com/Gabriel439/Haskell-Pipes-Library/issues/15#issuecomment-522994157

`forever` began to leak for `pipes` in #194 due to removing the
leak-free implementation of the `(*>)` operator.

Specifically, `forever` is implemented as:

```haskell
forever a = let a' = a *> a' in a'
```

... and in the absence of a specialized implementation of the `(*>)`
operator, it falls back on the default implementation, which is:

```haskell
a1 *> a2 = (id <$ a1) <*> a2
```

Unfortunately, that implementation leaks space, which is why `pipes`
requires a more efficient implementation, which this change restores.