### PR TITLE
GHC 9.0 support

### DIFF
--- a/src/Pipes.hs
+++ b/src/Pipes.hs
@@ -138,7 +138,7 @@ f '~>' 'yield' = f
 'yield' :: 'Monad' m => a -> 'Pipe'   x a m ()
 @
 -}
-yield :: Functor m => forall x' x . a -> Proxy x' x () a m ()
+yield :: Functor m => a -> Proxy x' x () a m ()
 yield = respond
 {-# INLINABLE [1] yield #-}
 
@@ -636,8 +636,13 @@ next = go
         Pure    r    -> return (Left r)
 {-# INLINABLE next #-}
 
--- | Convert a 'F.Foldable' to a 'Producer'
-each :: (Functor m, Foldable f) => f a -> Producer' a m ()
+{-| Convert a 'F.Foldable' to a 'Producer'
+
+@
+'each' :: ('Functor' m, 'Foldable' f) => f a -> 'Producer' a m ()
+@
+-}
+each :: (Functor m, Foldable f) => f a -> Proxy x' x () a m ()
 each = F.foldr (\a p -> yield a >> p) (return ())
 {-# INLINABLE each #-}
 {-  The above code is the same as:
@@ -648,8 +653,13 @@ each = F.foldr (\a p -> yield a >> p) (return ())
     build/foldr fusion
 -}
 
--- | Convert an 'Enumerable' to a 'Producer'
-every :: (Monad m, Enumerable t) => t m a -> Producer' a m ()
+{-| Convert an 'Enumerable' to a 'Producer'
+
+@
+'each' :: ('Monad' m, 'Enumerable' t) => t m a -> 'Producer' a m ()
+@
+-}
+every :: (Monad m, Enumerable t) => t m a -> Proxy x' x () a m ()
 every it = discard >\\ enumerate (toListT it)
 {-# INLINABLE every #-}
 

--- a/src/Pipes.hs
+++ b/src/Pipes.hs
@@ -134,10 +134,11 @@ f '~>' 'yield' = f
 {-| Produce a value
 
 @
-'yield' :: 'Monad' m => a -> 'Pipe' x a m ()
+'yield' :: 'Monad' m => a -> 'Producer' a m ()
+'yield' :: 'Monad' m => a -> 'Pipe'   x a m ()
 @
 -}
-yield :: Functor m => a -> Producer' a m ()
+yield :: Functor m => forall x' x . a -> Proxy x' x () a m ()
 yield = respond
 {-# INLINABLE [1] yield #-}
 

--- a/src/Pipes/Prelude.hs
+++ b/src/Pipes/Prelude.hs
@@ -184,8 +184,12 @@ readLn = stdinLn >-> read
 {-| Read 'String's from a 'IO.Handle' using 'IO.hGetLine'
 
     Terminates on end of input
+
+@
+'fromHandle' :: 'MonadIO' m => 'IO.Handle' -> 'Producer' 'String' m ()
+@
 -}
-fromHandle :: MonadIO m => IO.Handle -> Producer' String m ()
+fromHandle :: MonadIO m => IO.Handle -> Proxy x' x () String m ()
 fromHandle h = go
   where
     go = do
@@ -196,8 +200,11 @@ fromHandle h = go
             go
 {-# INLINABLE fromHandle #-}
 
--- | Repeat a monadic action indefinitely, 'yield'ing each result
-repeatM :: Monad m => m a -> Producer' a m r
+{-| Repeat a monadic action indefinitely, 'yield'ing each result
+
+'repeatM' :: 'Monad' m => m a -> 'Producer' a m r
+-}
+repeatM :: Monad m => m a -> Proxy x' x () a m r
 repeatM m = lift m >~ cat
 {-# INLINABLE [1] repeatM #-}
 
@@ -210,8 +217,12 @@ repeatM m = lift m >~ cat
 > replicateM  0      x = return ()
 >
 > replicateM (m + n) x = replicateM m x >> replicateM n x  -- 0 <= {m,n}
+
+@
+'replicateM' :: 'Monad' m => Int -> m a -> 'Producer' a m ()
+@
 -}
-replicateM :: Monad m => Int -> m a -> Producer' a m ()
+replicateM :: Monad m => Int -> m a -> Proxy x' x () a m ()
 replicateM n m = lift m >~ take n
 {-# INLINABLE replicateM #-}
 
@@ -914,9 +925,9 @@ toListM' = fold' step begin done
 
 -- | Zip two 'Producer's
 zip :: Monad m
-    => (Producer   a     m r)
-    -> (Producer      b  m r)
-    -> (Producer' (a, b) m r)
+    => (Producer       a     m r)
+    -> (Producer          b  m r)
+    -> (Proxy x' x () (a, b) m r)
 zip = zipWith (,)
 {-# INLINABLE zip #-}
 
@@ -925,7 +936,7 @@ zipWith :: Monad m
     => (a -> b -> c)
     -> (Producer  a m r)
     -> (Producer  b m r)
-    -> (Producer' c m r)
+    -> (Proxy x' x () c m r)
 zipWith f = go
   where
     go p1 p2 = do


### PR DESCRIPTION
Fixes https://github.com/Gabriel439/Haskell-Pipes-Library/issues/224

It appears that we need to either eta-expand `yield` or move the
universal quantification to the outside.  The latter seems to be a more
robust solution.