### PR TITLE
Build against `mmorph-1.2.0`

### DIFF
--- a/pipes.cabal
+++ b/pipes.cabal
@@ -49,7 +49,7 @@ Library
         base         >= 4.8     && < 5   ,
         transformers >= 0.2.0.0 && < 0.6 ,
         exceptions   >= 0.4     && < 0.11,
-        mmorph       >= 1.0.4   && < 1.2 ,
+        mmorph       >= 1.0.4   && < 1.3 ,
         mtl          >= 2.2.1   && < 2.3 ,
         void         >= 0.4     && < 0.8
 


### PR DESCRIPTION
Related to https://github.com/commercialhaskell/stackage/issues/6122